### PR TITLE
v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *.cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v1.0.0
+
+- added `--ttf` and `--otf` options to support definition of desired build file type
+- added support for parallel *.ttf and *.otf builds when they are requested in the same command. This means that parallel builds are now performed for every VARIANT x FILE TYPE combination in the command up to the number of processing units available on your machine.  Prior to this version, support was provided for parallel builds across font variants only
+- added help options and in-application help documentation
+- added usage option and in-application usage documentation
+- added version options and in-application version report
+
 ### v0.9.1
 
 - updated user message strings during script execution

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Christopher Simpkins
+Copyright (c) 2018 Christopher Simpkins
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+install-linux:
+	sudo mv dist/linux64/fontmake-mp /usr/local/bin/fontmake-mp
+
+install-macos:
+	sudo mv dist/macos64/fontmake-mp /usr/local/bin/fontmake-mp
+
+# Must be executed on Linux 64bit arch system
+linux-build:
+	rm *.pyc
+	pyinstaller -c --onefile --hidden-import=fontmake --clean --distpath="dist/linux64" -n fontmake-mp fmp.py
+
+# Must be executed on macOS 64bit arch system
+macos-build:
+	rm *.pyc
+	pyinstaller -c --onefile --hidden-import=fontmake --clean --distpath="dist/macos64" -n fontmake-mp fmp.py
+
+# cross-platform uninstall for users who installed with make targets above
+uninstall:
+	rm /usr/local/bin/fontmake-mp
+
+.PHONY: linux-build macos-build install-linux install-macos uninstall

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# fontmake-mp [![Build Status](https://semaphoreci.com/api/v1/sourcefoundry/fontmake-mp/branches/master/badge.svg)](https://semaphoreci.com/sourcefoundry/fontmake-mp)
+# fontmake-mp 
 
+[![Build Status](https://semaphoreci.com/api/v1/sourcefoundry/fontmake-mp/branches/master/badge.svg)](https://semaphoreci.com/sourcefoundry/fontmake-mp)
+[![GitHub release](https://img.shields.io/github/release/source-foundry/fontmake-mp.svg?style=flat-square)](https://github.com/source-foundry/fontmake-mp/releases/latest)
 
 ## About
 

--- a/fmp.py
+++ b/fmp.py
@@ -62,7 +62,9 @@ Fonts are compiled in the working directory on the directory path(s) master_otf 
 
 def main(argv):
     if len(argv) == 0:
-        sys.stderr.write("[ERROR] Please include at least one UFO path in your command." + os.linesep)
+        sys.stderr.write(
+            "[ERROR] Please include at least one UFO path in your command." + os.linesep
+        )
         sys.exit(1)
     # help, version, usage flag handling
     if argv[0] in ("-h", "--help"):
@@ -139,9 +141,7 @@ def main(argv):
 
     if len(source_path_list) == 1:
         # there is only one source compile necessary, skip spawning of processes and just build it
-        print(
-            "[*] Single font compile requested. No additional processes spawned..."
-        )
+        print("[*] Single font compile requested. No additional processes spawned...")
         print(" ")
 
         # begin compile

--- a/fmp.py
+++ b/fmp.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# ==================================================================
-#  fmp.py v1.0.0
+# ===================================================================
+#  fmp.py
 #    Concurrent font compilation from UFO source files with fontmake
 #
 #   Copyright 2018 Christopher Simpkins
 #   MIT License
 #
 #   Source Repository: https://github.com/source-foundry/fontmake-mp
-# ==================================================================
+# ===================================================================
 
 import sys
 import os
@@ -23,10 +23,58 @@ BUILD_FILE_TYPE = ("ttf", "otf")
 
 lock = Lock()
 
+VERSION_NUMBER = "1.0.0"
+VERSION = "fontmake-mp v" + VERSION_NUMBER
+USAGE = "[./fmp.py|fontmake-mp] (--ttf|--otf) [UFO file path 1] (UFO file path ...)"
+HELP = """
+===================================================================
+ fontmake-mp
+   Parallel font compilation from UFO source files with fontmake
+   
+   Copyright 2018 Christopher Simpkins
+   MIT License
+
+   Source Repository: https://github.com/source-foundry/fontmake-mp
+====================================================================
+
+fontmake-mp compiles *.otf and/or *.ttf font binaries from UFO source files in parallel.
+
+Execute fontmake-mp with the fmp.py Python script (located in the root of repository) or the fontmake-mp executable (located in the repository releases).
+
+Usage:
+  Execution of Python script:
+     $ python fmp.py (--ttf|--otf) [UFO file path 1] (UFO file path ...)
+     
+  Execution of executable file installed on system PATH
+     $ fontmake-mp (--ttf|--otf) [UFO file path 1] (UFO file path ...)
+     
+Options:
+  --otf          Build *.otf files only (optional, default=*.otf AND *.ttf)
+  --ttf          Build *.ttf files only (optional, default=*.otf AND *.ttf)
+  
+  -h, --help     Display help text
+      --usage    Display application usage
+  -v, --version  Display application version
+
+Fonts are compiled in the working directory on the directory path(s) master_otf and/or master_ttf.
+"""
+
 
 def main(argv):
+    # help, version, usage flag handling
+    if argv[0] in ("-h", "--help"):
+        print(HELP)
+        sys.exit(0)
+    elif argv[0] in ("-v", "--version"):
+        print(VERSION)
+        sys.exit(0)
+    elif argv[0] == "--usage":
+        print(USAGE)
+        sys.exit(0)
+
     processes = PROCESSES
 
+    # TODO: handle --ttf and --otf options
     source_path_list = argv
 
     # Command line error handling

--- a/fmp.py
+++ b/fmp.py
@@ -11,15 +11,15 @@
 #   Source Repository: https://github.com/source-foundry/fontmake-mp
 # ===================================================================
 
-import sys
 import os
+import sys
+import timeit
 import traceback
 
 from multiprocessing import Lock, Pool, cpu_count
 from fontmake.font_project import FontProject
 
 PROCESSES = 0
-BUILD_FILE_TYPE = ("ttf", "otf")
 
 lock = Lock()
 
@@ -61,6 +61,9 @@ Fonts are compiled in the working directory on the directory path(s) master_otf 
 
 
 def main(argv):
+    if len(argv) == 0:
+        sys.stderr.write("[ERROR] Please include at least one UFO path in your command." + os.linesep)
+        sys.exit(1)
     # help, version, usage flag handling
     if argv[0] in ("-h", "--help"):
         print(HELP)
@@ -74,8 +77,27 @@ def main(argv):
 
     processes = PROCESSES
 
-    # TODO: handle --ttf and --otf options
-    source_path_list = argv
+    # define the build file types in the request
+    build_file_types = []
+    if "--ttf" in argv:
+        build_file_types.append("ttf")
+    if "--otf" in argv:
+        build_file_types.append("otf")
+
+    if len(build_file_types) == 0:
+        build_file_types.append("ttf")
+        build_file_types.append("otf")
+
+    # create source path list with single UFO path per build type
+    # definition in order to parallelize builds across otf/ttf types
+    source_path_list = []
+    for arg in argv:
+        if arg[0] == "-":
+            pass
+        else:
+            for build_type in build_file_types:
+                # create a tuple of (source file path, build type)
+                source_path_list.append((arg, build_type))
 
     # Command line error handling
     if len(source_path_list) == 0:
@@ -85,29 +107,27 @@ def main(argv):
         )
         sys.exit(1)
 
-    for source_path in source_path_list:
-        if len(source_path) < 5:  # not a proper *.ufo file path
+    for source_path_tuple in source_path_list:
+        if len(source_path_tuple[0]) < 5:  # not a proper *.ufo file path
             sys.stderr.write(
                 "[ERROR] '"
-                + source_path
+                + source_path_tuple[0]
                 + "' is not properly formatted as a path to a UFO source "
                 "directory" + os.linesep
             )
             sys.exit(1)
-        elif (
-            not source_path[-4:] == ".ufo"
-        ):  # does not end with .ufo directory extension
+        elif not source_path_tuple[0][-4:] == ".ufo":  # does not end with .ufo
             sys.stderr.write(
                 "[ERROR] '"
-                + source_path
+                + source_path_tuple[0]
                 + "' does not appear to be a UFO source directory"
                 + os.linesep
             )
             sys.exit(1)
-        elif not os.path.isdir(source_path):  # is not an existing directory path
+        elif not os.path.isdir(source_path_tuple[0]):  # is not an existing directory
             sys.stderr.write(
                 "[ERROR] '"
-                + source_path
+                + source_path_tuple[0]
                 + "' does not appear to be a valid path to a UFO source "
                 "directory" + os.linesep
             )
@@ -120,10 +140,23 @@ def main(argv):
     if len(source_path_list) == 1:
         # there is only one source compile necessary, skip spawning of processes and just build it
         print(
-            "[*] Single font compile requested. Concurrency is not necessary.  No additional processes spawned..."
+            "[*] Single font compile requested. No additional processes spawned..."
         )
         print(" ")
+
+        # begin compile
+        start_time = timeit.default_timer()
+
         build_fonts(source_path_list[0])
+
+        elapsed_time = timeit.default_timer() - start_time
+        elapsed_time_string = "{0:.2f}".format(elapsed_time)
+        print(os.linesep + os.linesep + "---")
+        print("Build complete in " + elapsed_time_string + " seconds!")
+        if "ttf" in build_file_types:
+            print("*.ttf fonts in master_ttf directory")
+        if "otf" in build_file_types:
+            print("*.otf fonts in master_otf directory")
         sys.exit(0)
     else:
         # if not defined by user, start by defining spawned processes as number of available cores
@@ -147,21 +180,36 @@ def main(argv):
         print(" ")
         print(" ")
 
+        # begin compile
+        start_time = timeit.default_timer()
+
         p = Pool(processes)
         p.map(build_fonts, source_path_list)
+
+        elapsed_time = timeit.default_timer() - start_time
+        elapsed_time_string = "{0:.2f}".format(elapsed_time)
+        print(os.linesep + os.linesep + "---")
+        print("Build complete in " + elapsed_time_string + " seconds!")
+        if "ttf" in build_file_types:
+            print("*.ttf fonts in master_ttf directory")
+        if "otf" in build_file_types:
+            print("*.otf fonts in master_otf directory")
         sys.exit(0)
 
 
-def build_fonts(ufo_path):
+def build_fonts(ufo_path_tuple):
+    """build_fonts uses fontmake to build fonts from UFO source files with
+       the definitions in the ufo_path_tuple that is defined as
+       (UFO source path, build file type)"""
     try:
         fp = FontProject()
-        fp.run_from_ufos(ufo_path, output=BUILD_FILE_TYPE)
+        fp.run_from_ufos(ufo_path_tuple[0], output=ufo_path_tuple[1])
     except Exception as e:
         lock.acquire()
         print(" ")
         print(
             "[ERROR] The fontmake compile for "
-            + ufo_path
+            + ufo_path_tuple[0]
             + " failed with the following error"
             ":" + os.linesep
         )

--- a/fmp.py
+++ b/fmp.py
@@ -30,7 +30,7 @@ HELP = """
 ===================================================================
  fontmake-mp
    Parallel font compilation from UFO source files with fontmake
-   
+
    Copyright 2018 Christopher Simpkins
    MIT License
 
@@ -44,14 +44,14 @@ Execute fontmake-mp with the fmp.py Python script (located in the root of reposi
 Usage:
   Execution of Python script:
      $ python fmp.py (--ttf|--otf) [UFO file path 1] (UFO file path ...)
-     
+
   Execution of executable file installed on system PATH
      $ fontmake-mp (--ttf|--otf) [UFO file path 1] (UFO file path ...)
-     
+
 Options:
   --otf          Build *.otf files only (optional, default=*.otf AND *.ttf)
   --ttf          Build *.ttf files only (optional, default=*.otf AND *.ttf)
-  
+
   -h, --help     Display help text
       --usage    Display application usage
   -v, --version  Display application version

--- a/fmp.py
+++ b/fmp.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # ==================================================================
-#  fmp.py v0.9.1
+#  fmp.py v1.0.0
 #    Concurrent font compilation from UFO source files with fontmake
 #
 #   Copyright 2018 Christopher Simpkins
@@ -19,7 +19,7 @@ from multiprocessing import Lock, Pool, cpu_count
 from fontmake.font_project import FontProject
 
 PROCESSES = 0
-BUILD_FILE_TYPE = ('ttf', 'otf')
+BUILD_FILE_TYPE = ("ttf", "otf")
 
 lock = Lock()
 
@@ -31,21 +31,38 @@ def main(argv):
 
     # Command line error handling
     if len(source_path_list) == 0:
-        sys.stderr.write("[ERROR] Please include one or more paths to UFO source directories as "
-                         "arguments to the script." + os.linesep)
+        sys.stderr.write(
+            "[ERROR] Please include one or more paths to UFO source directories as "
+            "arguments to the script." + os.linesep
+        )
         sys.exit(1)
 
     for source_path in source_path_list:
-        if len(source_path) < 5:                # not a proper *.ufo file path
-            sys.stderr.write("[ERROR] '" + source_path + "' is not properly formatted as a path to a UFO source "
-                             "directory" + os.linesep)
+        if len(source_path) < 5:  # not a proper *.ufo file path
+            sys.stderr.write(
+                "[ERROR] '"
+                + source_path
+                + "' is not properly formatted as a path to a UFO source "
+                "directory" + os.linesep
+            )
             sys.exit(1)
-        elif not source_path[-4:] == ".ufo":    # does not end with .ufo directory extension
-            sys.stderr.write("[ERROR] '" + source_path + "' does not appear to be a UFO source directory" + os.linesep)
+        elif (
+            not source_path[-4:] == ".ufo"
+        ):  # does not end with .ufo directory extension
+            sys.stderr.write(
+                "[ERROR] '"
+                + source_path
+                + "' does not appear to be a UFO source directory"
+                + os.linesep
+            )
             sys.exit(1)
-        elif not os.path.isdir(source_path):    # is not an existing directory path
-            sys.stderr.write("[ERROR] '" + source_path + "' does not appear to be a valid path to a UFO source "
-                             "directory" + os.linesep)
+        elif not os.path.isdir(source_path):  # is not an existing directory path
+            sys.stderr.write(
+                "[ERROR] '"
+                + source_path
+                + "' does not appear to be a valid path to a UFO source "
+                "directory" + os.linesep
+            )
             sys.exit(1)
 
     # begin compile
@@ -54,7 +71,9 @@ def main(argv):
 
     if len(source_path_list) == 1:
         # there is only one source compile necessary, skip spawning of processes and just build it
-        print("[*] Single font compile requested. Concurrency is not necessary.  No additional processes spawned...")
+        print(
+            "[*] Single font compile requested. Concurrency is not necessary.  No additional processes spawned..."
+        )
         print(" ")
         build_fonts(source_path_list[0])
         sys.exit(0)
@@ -69,10 +88,14 @@ def main(argv):
         # if total cores available is greater than number of font compiles requested, limit to the latter number
         if processes > len(source_path_list):
             processes = len(source_path_list)
-            print("[*] Limiting spawned process number to the number of font compiles needed "
-                  "(" + str(processes) + ")...")
+            print(
+                "[*] Limiting spawned process number to the number of font compiles needed "
+                "(" + str(processes) + ")..."
+            )
 
-        print("[*] Output from the fontmake compiler will appear out of order below. This is expected...")
+        print(
+            "[*] Output from the fontmake compiler will appear out of order below. This is expected..."
+        )
         print(" ")
         print(" ")
 
@@ -88,8 +111,12 @@ def build_fonts(ufo_path):
     except Exception as e:
         lock.acquire()
         print(" ")
-        print("[ERROR] The fontmake compile for " + ufo_path + " failed with the following error"
-              ":" + os.linesep)
+        print(
+            "[ERROR] The fontmake compile for "
+            + ufo_path
+            + " failed with the following error"
+            ":" + os.linesep
+        )
         sys.stdout.flush()
         traceback.print_exc()
         print(str(e))
@@ -97,5 +124,5 @@ def build_fonts(ufo_path):
         lock.release()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv[1:])

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='fontmake-mp',
-    version='0.9.1',
+    version='1.0.0',
     description='A font vertical metrics reporting and line spacing adjustment tool',
     url='https://github.com/source-foundry/fontmake-mp',
     license='MIT license',

--- a/test_fmp.py
+++ b/test_fmp.py
@@ -13,11 +13,6 @@ def test_default_process_constant():
     assert fmp.PROCESSES == 0
 
 
-def test_default_build_types():
-    assert "ttf" in fmp.BUILD_FILE_TYPE
-    assert "otf" in fmp.BUILD_FILE_TYPE
-
-
 def test_missing_args(capsys):
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         main([])

--- a/test_fmp.py
+++ b/test_fmp.py
@@ -14,8 +14,8 @@ def test_default_process_constant():
 
 
 def test_default_build_types():
-    assert 'ttf' in fmp.BUILD_FILE_TYPE
-    assert 'otf' in fmp.BUILD_FILE_TYPE
+    assert "ttf" in fmp.BUILD_FILE_TYPE
+    assert "otf" in fmp.BUILD_FILE_TYPE
 
 
 def test_missing_args(capsys):
@@ -74,7 +74,12 @@ def test_single_font_build(capsys):
 
 
 def test_multiple_font_build(capsys):
-    ufo_paths = ["tests/Hack-Regular.ufo", "tests/Hack-Italic.ufo", "tests/Hack-Bold.ufo", "tests/Hack-BoldItalic.ufo"]
+    ufo_paths = [
+        "tests/Hack-Regular.ufo",
+        "tests/Hack-Italic.ufo",
+        "tests/Hack-Bold.ufo",
+        "tests/Hack-BoldItalic.ufo",
+    ]
     with pytest.raises(SystemExit) as pytest_wrapped_e:
         main(ufo_paths)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, pypy
+envlist = py27, py37, pypy
 
 [testenv]
 commands =


### PR DESCRIPTION
Adds:

- support for parallel builds across all VARIANT x BUILD TYPE combinations in a command line request
- help option
- usage option
- version option
- multi-platform pyinstaller builds of fontmake-mp that include an embedded Python interpreter and all project dependencies, can be downloaded from the repository releases
- new Makefile with make target support for installs/uninstalls